### PR TITLE
Fix Snapmaker Luban support

### DIFF
--- a/octoprint_prusaslicerthumbnails/__init__.py
+++ b/octoprint_prusaslicerthumbnails/__init__.py
@@ -70,7 +70,7 @@ class PrusaslicerthumbnailsPlugin(octoprint.plugin.SettingsPlugin,
 		regex = r"(?:^; thumbnail(?:_JPG)* begin \d+[x ]\d+ \d+)(?:\n|\r\n?)((?:.+(?:\n|\r\n?))+?)(?:^; thumbnail(?:_JPG)* end)"
 		regex_mks = re.compile('(?:;(?:simage|;gimage):).*?M10086 ;[\r\n]', re.DOTALL)
 		regex_weedo = re.compile('W221[\r\n](.*)[\r\n]W222', re.DOTALL)
-		regex_luban = re.compile(';thumbnail: data:image/png;base64,(.*)[\r\n]', re.DOTALL)
+		regex_luban = re.compile(';Thumbnail:data:image/png;base64,(.*)[\r\n]', re.DOTALL)
 		regex_qidi = re.compile('M4010.*\'(.*)\'', re.DOTALL)
 		regex_creality = r"(?:^; jpg begin .*)(?:\n|\r\n?)((?:.+(?:\n|\r\n?))+?)(?:^; jpg end)"
 		regex_buddy = r"(?:^; thumbnail(?:_QOI)* begin \d+[x ]\d+ \d+)(?:\n|\r\n?)((?:.+(?:\n|\r\n?))+?)(?:^; thumbnail(?:_QOI)* end)"


### PR DESCRIPTION
In the latest version of Luban, the formatting has changed slightly. (I am not sure when it was changed, I only just started using Luban)

Was
`;thumbnail: data:image/png;base64,`

Now
`;Thumbnail:data:image/png;base64,`

This adds Luban support back. This will only work with newly sliced gcodes.

Had to rename to txt due to github restrictions but here is a newly sliced benchy.
[3DBenchy_1706529863352.gcode.txt](https://github.com/Golumpa/OctoPrint-PrusaSlicerThumbnails/files/14213114/3DBenchy_1706529863352.gcode.txt)